### PR TITLE
feat: update the minimum supported SDK version to 24

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,4 +1,4 @@
-ext.cdvMinSdkVersion = 22
+ext.cdvMinSdkVersion = 24
 
 buildscript {
     repositories {


### PR DESCRIPTION
Cordova-Android 12 has been released and the minSdkVersion has changed from 22 to 24.

> Increased Minimum & Target SDK
> 
> This release has increased the minimum supported SDK version to 24 which is Android 7.0. It also has increased the target SDK to 33, Android 13.
> 
> https://cordova.apache.org/announcements/2023/05/22/cordova-android-12.0.0.html
