### PR TITLE
ios: fix to support newer cordova-ios@7.0.1, use tar instead of tar.gz2

### DIFF
--- a/install/hooks/ios/after-plugin-install.js
+++ b/install/hooks/ios/after-plugin-install.js
@@ -7,7 +7,7 @@ module.exports = function(context) {
   // Require the iOS platform Api to get the Xcode .pbxproj path.
   var iosPlatformPath = path.join(context.opts.projectRoot, 'platforms', 'ios');
   var iosAPI = require(path.join(iosPlatformPath, 'cordova', 'Api'));
-  var iosAPIInstance = new iosAPI();
+  var iosAPIInstance = new iosAPI('ios', iosPlatformPath);
   var pbxprojPath = iosAPIInstance.locations.pbxproj;
 
   // Read the Xcode project and get the target.

--- a/install/hooks/ios/before-plugin-install.js
+++ b/install/hooks/ios/before-plugin-install.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var targz2 = require('tar.gz2');
 
 const nodeProjectFolder = 'www/nodejs-project';
 const nodeMobileFolderPath = 'plugins/nodejs-mobile-cordova/libs/ios/nodemobile/';
@@ -17,16 +16,22 @@ module.exports = function(context) {
   return new Promise((resolve, reject) => {
       // Unzip and untar the libnode.Framework
     if (fs.existsSync(zipFilePath)) {
-        targz2().extract(zipFilePath, nodeMobileFolderPath, function(err) {
-        if (err) {
-            reject(err);
-        } else {
-            fs.unlinkSync(zipFilePath);
-            resolve();
-        }
-        });
+
+      var tar = require('tar');
+      tar.extract({
+        cwd: nodeMobileFolderPath,
+        file: zipFilePath,
+        onwarn: (code,msg,err) => {
+          reject(err);
+        },
+      })
+      .then(_ => {
+        fs.unlinkSync(zipFilePath);
+        resolve();
+      });
+
     } else if (!fs.existsSync(nodeMobileFilePath)) {
-        reject(new Error(nodeMobileFileName + ' is missing'));
+      reject(new Error(nodeMobileFileName + ' is missing'));
     } else {
         resolve();
     }

--- a/install/hooks/ios/before-plugin-uninstall.js
+++ b/install/hooks/ios/before-plugin-uninstall.js
@@ -41,7 +41,7 @@ module.exports = function(context) {
   // Require the iOS platform Api to get the Xcode .pbxproj path.
   var iosPlatformPath = path.join(context.opts.projectRoot, 'platforms', 'ios');
   var iosAPI = require(path.join(iosPlatformPath, 'cordova', 'Api'));
-  var iosAPIInstance = new iosAPI();
+  var iosAPIInstance = new iosAPI('ios', iosPlatformPath);
   var pbxprojPath = iosAPIInstance.locations.pbxproj;
 
   // Read the Xcode project and get the target.

--- a/install/hooks/ios/fix-xcframework-path.js
+++ b/install/hooks/ios/fix-xcframework-path.js
@@ -5,7 +5,7 @@ module.exports = function(context) {
   // Require the iOS platform Api to get the Xcode .pbxproj path.
   var iosPlatformPath = path.join(context.opts.projectRoot, 'platforms', 'ios');
   var iosAPI = require(path.join(iosPlatformPath, 'cordova', 'Api'));
-  var iosAPIInstance = new iosAPI();
+  var iosAPIInstance = new iosAPI('ios', iosPlatformPath);
   var pbxprojPath = iosAPIInstance.locations.pbxproj;
   var rootIosProjDir = iosAPIInstance.locations.root;
   var cordovaProjPath = iosAPIInstance.locations.xcodeCordovaProj;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "nodejs-mobile-gyp": "^0.3.1",
-    "tar.gz2": "^1.0.0",
+    "tar": "^6.2.0",
     "xcode": "^2.0.0"
   },
   "homepage": "https://code.janeasystems.com/nodejs-mobile",


### PR DESCRIPTION
working with cordova 12, both android and ios tested.

use npm package 'tar' instead of 'tar.gz2' to avoid:
3 high severity vulnerabilities
